### PR TITLE
Fix #1 - Reorder main loop cycle

### DIFF
--- a/main.py
+++ b/main.py
@@ -59,8 +59,8 @@ def main():
         stages.MEM()
         stages.EX()
         stages.ID()
-        stages.ID_hzd()
         stages.IF()
+        stages.ID_hzd()
 
         # Keep only the 32 LSB from memory
         for i in range(len(G_MEM.REGS)):


### PR DESCRIPTION
This fix worked for me,
what happened is that the controls on the ID stage were compared to the same instruction from the prior cycle, so obviously RT was equal to RD on `lw` instructions because it is the same instruction... 
By reordering the cycle stages, the controls on the IF stage are updated and only after that, the ID hazard check is comparing the correct values with the load instruction.